### PR TITLE
Hotfix: Close modal when user clicks away

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -17,8 +17,9 @@ const Modal = ({modalHeader, children}: Props) => {
   }
 
   return (
-    <div className='absolute top-0 left-0 right-0 h-screen w-screen bg-grey-975/[0.33] dark:bg-grey-200/[0.33] flex justify-center pt-[53px] z-50'>
-      <div className='flex flex-col w-[750px] h-[780px] bg-white dark:bg-grey-850 rounded-[20px]'>
+    <>
+      <div className='fixed inset-0 bg-grey-975/[0.33] dark:bg-grey-200/[0.33] z-50' onClick={handleClose} />
+      <div className='fixed left-2/4 translate-x-[-50%] w-[750px] h-[780px] bg-white dark:bg-grey-850 rounded-[20px] justify-center mt-[53px] z-50'>
         <div className='flex h-[61px] flex-row-reverse items-center w-full border-b-[1px] border-grey-300'>
           <button className='mr-[29px]' onClick={handleClose}>
             <CloseIcon className='w-[14px] h-[14px]' />
@@ -32,7 +33,7 @@ const Modal = ({modalHeader, children}: Props) => {
           {children}
         </div>
       </div>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
Adjusted styles and added onClick handler to overlay to close modal when clicked