### PR TITLE
Hotfix: PTL-96-Sentry Enviroment Variables

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,7 +22,7 @@ const sentryWebpackPluginOptions = {
   // recommended:
   //   release, url, org, project, authToken, configFile, stripPrefix,
   //   urlPrefix, include, ignore
-
+  authToken: process.env.SENTRY_AUTH_TOKEN,
   silent: true, // Suppresses all logs
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.


### PR DESCRIPTION
Attempt explicit reference to authToken in nextJS.config