### PR TITLE
PTL-182 Download button bug

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -19,7 +19,7 @@ const Modal = ({modalHeader, children}: Props) => {
 
   return (
     <FocusTrap>
-      <div>
+      <div id='modal-download-target'> {/* Allows the downloadAsset service to work inside of modals when focus trapped*/}
         <div className='fixed inset-0 bg-grey-975/[0.33] dark:bg-grey-200/[0.33] z-50' onClick={handleClose} />
         <div className='fixed left-2/4 translate-x-[-50%] w-[750px] bg-white dark:bg-grey-850 rounded-[20px] justify-center mt-[53px] z-50'>
           <div className='flex h-[61px] flex-row-reverse items-center w-full border-b-[1px] border-grey-300 dark:border-grey-800'>

--- a/src/services/downloadAsset.ts
+++ b/src/services/downloadAsset.ts
@@ -12,9 +12,10 @@ const downloadAsset = async (url, filename) => {
       res.arrayBuffer().then(function (buffer) {
         const url = window.URL.createObjectURL(new Blob([buffer]))
         const link = document.createElement('a')
+        const modalDownloadTarget = document.querySelector('#modal-download-target') // Modals require a different element due to focus trap
         link.href = url
         link.setAttribute('download', filename)
-        document.body.appendChild(link)
+        modalDownloadTarget ? modalDownloadTarget.appendChild(link) : document.body.appendChild(link)
         link.click()
       })
         .catch((err) => {
@@ -27,3 +28,4 @@ const downloadAsset = async (url, filename) => {
 }
 
 export default downloadAsset
+


### PR DESCRIPTION
The bug here is that Focustrap (rightly) disallows clicks to elements that are not inside of it.  Since the downloadAsset appends to document.body it wont allow the click...

I fixed the bug by assigning an alternate modal element to append to when available, this should ensure it works for all modals as well as when there is no modal. But is something to bear in mind if we use Focus lock and downloadAsset in combination elsewhere (unlikely) but I have left comments to hint at what needs to be done