### PR TITLE
Hotfix: duplicate get plans api calls

### DIFF
--- a/src/__tests__/asset-comparator.test.tsx
+++ b/src/__tests__/asset-comparator.test.tsx
@@ -11,7 +11,11 @@ jest.mock('components/CredentialsModal', () => () => <div data-testid='credentia
 jest.mock('components/PlansList', () => () => <div data-testid='plan-list' />)
 jest.mock('components/AssetGrid', () => () => <div data-testid='asset-grid' />)
 jest.mock('hooks/useGetPlansHook', () => ({
-  useGetPlansHook: jest.fn(),
+  useGetPlansHook: jest.fn().mockImplementation(() => ({
+    resetDevPlans: jest.fn(),
+    resetStagingPlans: jest.fn(),
+    resetProdPlans: jest.fn(),
+  })),
 }))
 
 describe('AssetComparatorPage', () => {

--- a/src/components/CredentialsModal/CredentialsModal.tsx
+++ b/src/components/CredentialsModal/CredentialsModal.tsx
@@ -2,7 +2,6 @@ import {ReactNode, useState, useCallback} from 'react'
 import {Button, Modal, Tag, TextInputGroup} from 'components'
 import VerificationTag from './components/VerificationTag'
 import {useVerificationHook} from 'hooks/useVerificationHook'
-import {useGetPlansHook} from 'hooks/useGetPlansHook'
 import {EnvironmentName, ModalStyle} from 'utils/enums'
 import {
   getDevVerificationToken,
@@ -17,7 +16,11 @@ import {TagStyle, TagSize} from 'components/Tag/styles'
 import {ButtonType, ButtonWidth, ButtonSize, ButtonBackground, LabelColour, LabelWeight} from 'components/Button/styles'
 import {InputType, InputWidth, InputColour, InputStyle} from 'components/TextInputGroup/styles'
 
-const CredentialsModal = () => {
+type Props = {
+  removeTokenHandler: (envKey: string) => void
+}
+
+const CredentialsModal = ({removeTokenHandler}: Props) => {
   const [emailValue, setEmailValue] = useState('')
   const [isEmailReadyForValidation, setIsEmailReadyForValidation] = useState(false)
   const [passwordValue, setPasswordValue] = useState('')
@@ -40,8 +43,6 @@ const CredentialsModal = () => {
     resetStagingToken,
     resetProdToken,
   } = useVerificationHook()
-
-  const {resetDevPlans, resetStagingPlans, resetProdPlans} = useGetPlansHook()
 
   const {
     AQUAMARINE_FILLED,
@@ -84,17 +85,15 @@ const CredentialsModal = () => {
     if (envKey === 'DEV') {
       resetDevToken()
       removeDevVerificationToken()
-      resetDevPlans()
     } else if (envKey === 'STAGING') {
       resetStagingToken()
       removeStagingVerificationToken()
-      resetStagingPlans()
     } else if (envKey === 'PROD') {
       resetProdToken()
       removeProdVerificationToken()
-      resetProdPlans()
     }
-  }, [resetDevToken, resetDevPlans, resetStagingToken, resetStagingPlans, resetProdToken, resetProdPlans])
+    removeTokenHandler(envKey)
+  }, [resetDevToken, resetStagingToken, resetProdToken, removeTokenHandler])
 
   const renderVerificationTag = (envKey: string): ReactNode => {
     let isSuccessful, isPending, isFailure, hasVerificationToken

--- a/src/pages/asset-comparator.tsx
+++ b/src/pages/asset-comparator.tsx
@@ -25,7 +25,8 @@ const AssetComparatorPage: NextPage = () => {
   const modalRequested: ModalType = useAppSelector(selectModal)
   const planAssets: SelectedPlanImages = useAppSelector(getSelectedPlanImages)
   const isDesktopViewportDimensions = useIsDesktopViewportDimensions()
-  useGetPlansHook()
+
+  const {resetDevPlans, resetStagingPlans, resetProdPlans} = useGetPlansHook()
 
   const handleRequestCredentialsModal = useCallback(() => { dispatch(requestModal(ModalType.ASSET_COMPARATOR_CREDENTIALS)) }, [dispatch])
 
@@ -102,9 +103,19 @@ const AssetComparatorPage: NextPage = () => {
     )
   }
 
+  const handleTokenRemoval = (envKey: string) => {
+    if (envKey === 'DEV') {
+      resetDevPlans()
+    } else if (envKey === 'STAGING') {
+      resetStagingPlans()
+    } else if (envKey === 'PROD') {
+      resetProdPlans()
+    }
+  }
+
   return (
     <>
-      {modalRequested === ModalType.ASSET_COMPARATOR_CREDENTIALS && <CredentialsModal />}
+      {modalRequested === ModalType.ASSET_COMPARATOR_CREDENTIALS && <CredentialsModal removeTokenHandler={handleTokenRemoval} />}
       {modalRequested === ModalType.ASSET_COMPARATOR_ASSET && <AssetModal />}
       <PageLayout>
         <div data-testid='header' className='flex gap-[20px] h-[40px] justify-end'>


### PR DESCRIPTION
Removing context of get plans api from the credentials model and relying on the asset comparator to handle the relevant removal of plans.

To test, clear environment tokens, re-verify credentials and observe in the dev tool network tab that each environment should request the plans no more once it has received a successful response