### PR TITLE
PTL-229 Accessible plan list

### DIFF
--- a/src/components/TextInputGroup/TextInputGroup.tsx
+++ b/src/components/TextInputGroup/TextInputGroup.tsx
@@ -130,6 +130,7 @@ const TextInputGroup = (props: Props) => {
       <div className='relative'>
         <Combobox value={selectedValue} onChange={handleSelectItemClick}>
           <Combobox.Input as='input' ref={inputRef}
+            aria-label='Plan List'
             displayValue={() => value}
             autoComplete='off'
             onChange={onChange}
@@ -182,7 +183,6 @@ const TextInputGroup = (props: Props) => {
       </div>
     </>
   )
-
 
   const renderInputType = (inputType: number): ReactNode => {
     if (inputType === InputType.SEARCH || inputType === InputType.TEXT || inputType === InputType.PASSWORD) {


### PR DESCRIPTION
- Added classes to highlight plan list item in focus (taking a random stab at what the styling should be)
- Added missing aria-label for combobox input

Though I agreed with you (George) when you mentioned it, in the end I decided to leave the 'drop down arrow' where it was as when using the keyboard it's quite an easy way to open and close the modal without performing an action. That's a little subjective but I don't think there is too much harm in having it.