### PR TITLE
Hotfix: Staging environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@sentry/nextjs": "^6.17.4",
     "@types/jest": "^27.4.1",
     "axios": "^0.25.0",
+    "env-cmd": "^10.1.0",
     "eslint-plugin-jest": "^25.7.0",
     "focus-trap-react": "^8.9.2",
     "just-debounce-it": "^3.0.1",

--- a/src/components/DirectoryPlanModal/DirectoryPlanModal.tsx
+++ b/src/components/DirectoryPlanModal/DirectoryPlanModal.tsx
@@ -39,20 +39,22 @@ const DirectoryPlanModal = () => {
 
   const handlePostPlanError = useCallback(() => {
     const {status, data} = postPlanError as RTKQueryErrorResponse
-    const {detail} = data
 
-    // TODO: Handle error responses other that 409 (duplicate) and everything else
-    detail.map(err => {
-      const {loc, msg} = err
-      const location = loc[1]
-      if (location === 'name') {
-        setNameValidationError(status as unknown === 409 ? 'Name already exists' : msg)
-      } else if (location === 'plan_id') {
-        setPlanIdValidationError(status as unknown === 409 ? 'Plan ID already exists' : msg)
-      } else if (location === 'slug') {
-        setSlugValidationError(status as unknown === 409 ? 'Slug already exists' : msg)
-      }
-    })
+    if (data && data.detail) {
+      const {detail} = data
+      // TODO: Handle error responses other that 409 (duplicate) and everything else
+      detail.map(err => {
+        const {loc, msg} = err
+        const location = loc[1]
+        if (location === 'name') {
+          setNameValidationError(status as unknown === 409 ? 'Name already exists' : msg)
+        } else if (location === 'plan_id') {
+          setPlanIdValidationError(status as unknown === 409 ? 'Plan ID already exists' : msg)
+        } else if (location === 'slug') {
+          setSlugValidationError(status as unknown === 409 ? 'Slug already exists' : msg)
+        }
+      })
+    }
   }, [postPlanError])
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,6 +2644,11 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
@@ -3108,6 +3113,14 @@ entities@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
+
+env-cmd@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
+  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
+  dependencies:
+    commander "^4.0.0"
+    cross-spawn "^7.0.0"
 
 error-ex@^1.3.1:
   version "1.3.2"


### PR DESCRIPTION
Added `env-cmd` package to allow us to take advantage of the staging environment variables. Also added fix for unavailable data from post plan error response.

This will also require a change in our build script, to swap out the `yarn build` command for `env-cmd -f .env.staging yarn build `, when building for staging.