### PR TITLE
Hotfix: PTL-241-Dropdown Border Fix

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -19,7 +19,7 @@ const Dropdown = ({label, displayValue, displayValues, onChangeDisplayValue, has
         <Listbox.Button className={classNames(
           'flex flex-row items-center w-auto pl-[12px] text-grey-600 h-full bg-white dark:bg-grey-825 rounded-[10px]',
           open && 'rounded-none rounded-t-[10px]',
-          hasShadow ? 'shadow-[0_1px_6px_0px_rgba(0,0,0,0.5)]' : 'border-[1px] border-grey-300 dark:border-grey-700',
+          hasShadow ? 'shadow-[0_1px_6px_0px_rgba(0,0,0,0.5)]' : 'border-[1px] border-grey-500 dark:border-grey-700',
         )}
         >
           {label && (
@@ -34,7 +34,7 @@ const Dropdown = ({label, displayValue, displayValues, onChangeDisplayValue, has
         {open && (
           <Listbox.Options static className={classNames(
             'absolute z-10 w-full bg-white dark:bg-grey-825 rounded-b-[10px]',
-            hasShadow ? 'shadow-[0_1px_6px_0px_rgba(0,0,0,0.5)]' : 'border-[1px] border-grey-300 dark:border-grey-700',
+            hasShadow ? 'shadow-[0_1px_6px_0px_rgba(0,0,0,0.5)]' : 'border-b-[1px] border-l-[1px] border-r-[1px] border-grey-500 dark:border-grey-700',
           )}
           >
             {displayValues.map((value) => (


### PR DESCRIPTION
tweaked dropdown border to match abstract visuals (as opposed to the values actually in Abstract)