### PR TITLE
Hotfix: Fix location single view label and secondary mids single view payment scheme status options

### DIFF
--- a/src/__tests__/SingleViewLocationDetails.test.tsx
+++ b/src/__tests__/SingleViewLocationDetails.test.tsx
@@ -95,7 +95,7 @@ describe('SingleViewLocationDetails', () => {
 
     it('should render the Merchant ID heading and value', () => {
       render(getSingleViewLocationDetailsComponent())
-      expect(screen.getAllByRole('heading')[3]).toHaveTextContent('MERCHANT ID')
+      expect(screen.getAllByRole('heading')[3]).toHaveTextContent('MERCHANT INTERNAL ID')
       expect(screen.getByText(mockMerchantInternalId)).toBeInTheDocument()
     })
 

--- a/src/components/DirectorySingleViewModal/components/SingleViewLocation/components/SingleViewLocationDetails/SingleViewLocationDetails.tsx
+++ b/src/components/DirectorySingleViewModal/components/SingleViewLocation/components/SingleViewLocationDetails/SingleViewLocationDetails.tsx
@@ -206,7 +206,7 @@ const SingleViewLocationDetails = ({isInEditState, location}: Props) => {
 
         <div className='flex flex-col gap-[32px]'>
           <section>
-            <h2 className='font-single-view-heading'>MERCHANT ID</h2>
+            <h2 className='font-single-view-heading'>MERCHANT INTERNAL ID</h2>
             <p className='font-single-view-data'>{merchantInternalId}</p>
           </section>
 

--- a/src/components/DirectorySingleViewModal/components/SingleViewSecondaryMid/components/SingleViewSecondaryMidDetails/SingleViewSecondaryMidDetails.tsx
+++ b/src/components/DirectorySingleViewModal/components/SingleViewSecondaryMid/components/SingleViewSecondaryMidDetails/SingleViewSecondaryMidDetails.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import {useState, useMemo} from 'react'
 import {Button, Dropdown} from 'components'
 import {ButtonType, ButtonWidth, ButtonSize, ButtonBackground, LabelColour, LabelWeight} from 'components/Button/styles'
 import {PaymentSchemeCode, PaymentSchemeStartCaseName} from 'utils/enums'
@@ -9,8 +9,8 @@ type Props = {
 }
 
 const SingleViewSecondaryMidDetails = ({secondaryMid}: Props) => {
-  const displayValues = ['Not enrolled']
-  const [displayValue, setDisplayValue] = useState(displayValues[0])
+  const paymentSchemeStatusValues = useMemo(() => ['Enrolled', 'Enrolling', 'Not enrolled', 'Removed'], [])
+  const [paymentSchemeStatus, setPaymentSchemeStatus] = useState('Not enrolled')
 
   const {date_added: dateAdded, secondary_mid_metadata: secondaryMidMetadata, txm_status: txmStatus} = secondaryMid
   const {payment_scheme_code: paymentSchemeCode} = secondaryMidMetadata
@@ -36,9 +36,9 @@ const SingleViewSecondaryMidDetails = ({secondaryMid}: Props) => {
           <h2 className='font-single-view-heading'>PAYMENT SCHEME</h2>
           <p className='font-single-view-data'>{getPaymentScheme()}</p>
         </div>
-        <div className='flex flex-col h-[50px]'>
-          <label className='font-single-view-heading pl-[15px]'>PAYMENT SCHEME STATUS</label>
-          <Dropdown displayValue={displayValue} displayValues={displayValues} onChangeDisplayValue={setDisplayValue} />
+        <div className='flex flex-col h-[50px] pl-[15px]'>
+          <label className='font-single-view-heading'>PAYMENT SCHEME STATUS</label>
+          <Dropdown displayValue={paymentSchemeStatus} displayValues={paymentSchemeStatusValues} onChangeDisplayValue={setPaymentSchemeStatus} />
         </div>
       </section>
       <section className=' h-[38px] flex justify-between mb-[34px] items-center'>


### PR DESCRIPTION
Added additional payment scheme status options to the secondary mids single view modal. Also renamed label in the location single view modal.