### PR TITLE
Hotfix-369-customer wallet bugs

### DIFF
--- a/src/__tests__/LoyaltyCard.test.tsx
+++ b/src/__tests__/LoyaltyCard.test.tsx
@@ -162,7 +162,25 @@ describe('LoyaltyCard', () => {
     expect(screen.getByText('N/A')).toBeInTheDocument()
   })
 
-  describe('Test PLL balance strings', () => {
+  it('should render N/A for unauthorised PLL loyalty cards', () => {
+    const mockPllPlan = {...mockPlan, feature_set: {card_type: 2}, slug: 'iceland-bonus-card'} // Otherwise valid PLL plan
+    const mockUnauthorisedLoyaltyCard = {
+      ...mockLoyaltyCard,
+      status: {
+        state: 'Not authorised',
+        reason_codes: ['mock_reason_code'],
+      },
+    }
+    render(<LoyaltyCard card={mockUnauthorisedLoyaltyCard} getStatusFn={jest.fn()} plan={mockPllPlan} />)
+
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+  })
+
+  describe('Test authorised PLL balance strings', () => {
+    beforeAll(() => {
+      mockLoyaltyCard.status.state = 'authorised'
+    })
+
     it('should render correct balance string for Iceland cards', () => {
       const mockIcelandPlan = {...mockPlan, feature_set: {card_type: 2}, slug: 'iceland-bonus-card'}
       render(<LoyaltyCard card={mockLoyaltyCard} getStatusFn={jest.fn()} plan={mockIcelandPlan} />)

--- a/src/components/CustomerWalletsContainer/components/CustomerWallet/components/LoyaltyCard/LoyaltyCard.tsx
+++ b/src/components/CustomerWalletsContainer/components/CustomerWallet/components/LoyaltyCard/LoyaltyCard.tsx
@@ -56,7 +56,7 @@ const LoyaltyCard = ({getStatusFn, card, plan}: Props) => {
           </div>
           <div className='basis-3/4 leading-snug inline'>
             <p>{id}</p>
-            <p>{isPllCard ? getBalanceString(card, plan) : 'N/A'}</p>
+            <p>{isPllCard && status.state === 'authorised' ? getBalanceString(card, plan) : 'N/A'}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
added additional check for cards being active before a balance string can be rendered