### PR TITLE
PTL-387 - Remove Copied prompt in DirectoryMerchantTableRow

### DIFF
--- a/src/components/DirectoryMerchantDetailsTable/components/DirectoryMerchantDetailsTableRow/DirectoryMerchantDetailsTableRow.tsx
+++ b/src/components/DirectoryMerchantDetailsTable/components/DirectoryMerchantDetailsTableRow/DirectoryMerchantDetailsTableRow.tsx
@@ -39,6 +39,7 @@ const DirectoryMerchantDetailsTableRow = ({index, row, checked, onCheckboxChange
   const handleRowClick = () => {
     singleViewRequestHandler(index)
     dispatch(requestModal(ModalType.MID_MANAGEMENT_DIRECTORY_SINGLE_VIEW))
+    setCopyRow(null)
   }
 
   const handleCopyButtonClick = (e:React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
set copy row to null when modal is called. 

There is a ideal approach where we store what is copied so that the single view modal and TableRow can update accordingly based on what is copied but I can't justify that much extra code for such a minor benefit!