### PR TITLE
PTL-463: Checked table rows not unchecking

### DIFF
--- a/src/components/DirectoryMerchantDetailsTable/DirectoryMerchantDetailsTable.tsx
+++ b/src/components/DirectoryMerchantDetailsTable/DirectoryMerchantDetailsTable.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useEffect, useState} from 'react'
 import {DirectoryMerchantDetailsTableHeader, DirectoryMerchantDetailsTableCell} from 'types'
 import DirectoryMerchantDetailsTableRow from './components/DirectoryMerchantDetailsTableRow'
-import {setSelectedDirectoryTableCheckedRows, getSelectedDirectoryTableCheckedRows} from 'features/directoryMerchantSlice'
+import {setSelectedDirectoryTableCheckedRows, getSelectedDirectoryTableCheckedRows, resetSelectedDirectoryEntities} from 'features/directoryMerchantSlice'
 import {useAppDispatch, useAppSelector} from 'app/hooks'
 
 type TableRowProps = DirectoryMerchantDetailsTableCell[]
@@ -21,6 +21,12 @@ const DirectoryMerchantDetailsTable = ({tableHeaders, tableRows, checkboxChangeH
 
   const dispatch = useAppDispatch()
   const selectedCheckedRows = useAppSelector(getSelectedDirectoryTableCheckedRows)
+
+  useEffect(() => { // When component unmounts, clear out the current selected entities
+    return () => {
+      dispatch(resetSelectedDirectoryEntities())
+    }
+  }, [dispatch])
 
   useEffect(() => { // If actions are to occur in parent when checkboxes change, emit event to parent
     if (checkboxChangeHandler) {
@@ -74,7 +80,17 @@ const DirectoryMerchantDetailsTable = ({tableHeaders, tableRows, checkboxChangeH
       </thead>
 
       <tbody>
-        {tableRows.map((row, index) => <DirectoryMerchantDetailsTableRow key={index} index={index} refValue={refArray[index]} row={row} copyRow={copyRow} setCopyRow={setCopyRow} singleViewRequestHandler={singleViewRequestHandler} onCheckboxChange={handleCheckboxChange}/>)}
+        {tableRows.map((row, index) => (
+          <DirectoryMerchantDetailsTableRow
+            key={index}
+            index={index}
+            refValue={refArray[index]}
+            row={row}
+            copyRow={copyRow}
+            setCopyRow={setCopyRow}
+            singleViewRequestHandler={singleViewRequestHandler}
+            onCheckboxChange={handleCheckboxChange}/>
+        ))}
       </tbody>
     </table>
   )

--- a/src/features/directoryMerchantSlice.ts
+++ b/src/features/directoryMerchantSlice.ts
@@ -42,8 +42,12 @@ export const directoryMerchantSlice = createSlice({
     setSelectedDirectoryEntityCheckedSelection: (state, action) => {
       state.selectedEntityCheckedSelection = action.payload
     },
-    setSelectedDirectoryTableCheckedRows: (state, action) => { //
+    setSelectedDirectoryTableCheckedRows: (state, action) => {
       state.selectedTableCheckedRows = action.payload
+    },
+    resetSelectedDirectoryEntities: (state) => {
+      state.selectedEntityCheckedSelection = []
+      state.selectedTableCheckedRows = []
     },
     reset: () => initialState,
   },
@@ -55,6 +59,7 @@ export const {
   setSelectedDirectoryMerchantPaymentScheme,
   setSelectedDirectoryEntityCheckedSelection,
   setSelectedDirectoryTableCheckedRows,
+  resetSelectedDirectoryEntities,
   reset,
 } = directoryMerchantSlice.actions
 


### PR DESCRIPTION
Clearing out currently selected table entities when tabs are changed and component unmounts.