### PR TITLE
PTL-448: Payment scheme icons not displaying in Safari

### DIFF
--- a/src/components/Comments/components/Comment/Comment.tsx
+++ b/src/components/Comments/components/Comment/Comment.tsx
@@ -27,7 +27,7 @@ const Comment = ({comment, currentRoute, optionsMenuItems}: Props) => {
         {iconSlug && (
           <PaymentCardIcon
             paymentSchemeCode={PaymentSchemeCode[iconSlug.toUpperCase()]}
-            paymentSchemeIconStyles='flex min-w-[17px] min-h-[12px] justify-center mx-[2px] items-center rounded-[2px]'
+            paymentSchemeIconStyles='flex min-w-[17px] min-h-[12px] w-[17px] h-[12px] justify-center mx-[2px] items-center rounded-[2px]'
           />
         )}
       </>

--- a/src/components/Modals/components/BulkCommentModal/BulkCommentModal.tsx
+++ b/src/components/Modals/components/BulkCommentModal/BulkCommentModal.tsx
@@ -66,7 +66,7 @@ const BulkCommentModal = () => {
           {paymentSchemeCode && (
             <PaymentCardIcon
               paymentSchemeCode={paymentSchemeCode}
-              paymentSchemeIconStyles='flex min-w-[17px] min-h-[12px] justify-center mx-[2px] items-center'
+              paymentSchemeIconStyles='flex w-[17px] h-[12px] justify-center mx-[2px] items-center'
             />
           )}
         </div>

--- a/src/components/PaymentCardIcon/PaymentCardIcon.tsx
+++ b/src/components/PaymentCardIcon/PaymentCardIcon.tsx
@@ -16,19 +16,19 @@ const PaymentCardIcon = ({paymentSchemeCode, paymentSchemeIconStyles = defaultPa
       case PaymentSchemeCode.VISA:
         return (
           <div className={`${paymentSchemeIconStyles} bg-visaBlue`}>
-            <VisaSvg className='scale-[90%] mr-[1px]' alt='Visa' />
+            <VisaSvg className='scale-[90%] mr-[1px] h-full w-full' alt='Visa' />
           </div>
         )
       case PaymentSchemeCode.MASTERCARD:
         return (
           <div className={`${paymentSchemeIconStyles} bg-mastercardBlue`}>
-            <MastercardSvg className='scale-[78%]' alt='Mastercard' />
+            <MastercardSvg className='scale-[78%] h-full w-full' alt='Mastercard' />
           </div>
         )
       case PaymentSchemeCode.AMEX:
         return (
           <div className={`${paymentSchemeIconStyles} bg-amexBlue`}>
-            <AmexSvg className='scale-[85%]' alt='Amex' />
+            <AmexSvg className='scale-[85%] h-full w-full' alt='Amex' />
           </div>
         )
       default: return null


### PR DESCRIPTION
Providing a height and width value for the payment scheme icon