### PR TITLE
PTL-507: Safari edit comment button click closing edit state bug 

### DIFF
--- a/src/components/AutosizeTextArea/AutosizeTextArea.tsx
+++ b/src/components/AutosizeTextArea/AutosizeTextArea.tsx
@@ -82,7 +82,7 @@ const AutosizeTextArea = ({accessibilityLabel, placeholder, prePopulatedValue = 
           {inputValidationError}
         </span>
       )}
-      <button id='submit-button' data-testid='submit-button' aria-label={`${accessibilityLabel} button`} className='absolute right-[10px] bottom-[14px]'>
+      <button onMouseDown={(e) => e.preventDefault()} id='submit-button' data-testid='submit-button' aria-label={`${accessibilityLabel} button`} className='absolute right-[10px] bottom-[14px]'>
         <ArrowRightSvg className='h-[22px] w-[22px]' />
       </button>
     </form>


### PR DESCRIPTION
Added onMouseDown handler on submit button as Safari does not recognise e.relatedTarget when form blurs due to button click