### PR TITLE
Hotfix: Update POST comment to use correct owner_type

### DIFF
--- a/src/components/DirectoryMerchantIdentifiers/DirectoryMerchantIdentifiers.tsx
+++ b/src/components/DirectoryMerchantIdentifiers/DirectoryMerchantIdentifiers.tsx
@@ -10,7 +10,7 @@ import AddMastercardSvg from 'icons/svgs/add-mastercard.svg'
 import {DirectoryMerchantDetailsTableHeader, DirectoryMerchantDetailsTableCell} from 'types'
 import {requestModal} from 'features/modalSlice'
 import {CommentsSubjectTypes, ModalType} from 'utils/enums'
-import {setCommentsSubjectType, setModalHeader} from 'features/directoryCommentsSlice'
+import {setCommentsRef, setCommentsSubjectType, setModalHeader} from 'features/directoryCommentsSlice'
 
 const identifiersTableHeaders: DirectoryMerchantDetailsTableHeader[] = [
   {
@@ -96,6 +96,7 @@ const DirectoryMerchantIdentifiers = () => {
     // TODO: Will possibly need to change from Identifiers to PSIMIs
     setSelectedIdentifiers()
     dispatch(setModalHeader('Identifier Comment'))
+    dispatch(setCommentsRef(merchantId as string))
     dispatch(setCommentsSubjectType(CommentsSubjectTypes.PSIMI))
     dispatch(requestModal(ModalType.MID_MANAGEMENT_BULK_COMMENT))
   }

--- a/src/components/DirectoryMerchantLocations/DirectoryMerchantLocations.tsx
+++ b/src/components/DirectoryMerchantLocations/DirectoryMerchantLocations.tsx
@@ -7,7 +7,7 @@ import {DirectoryLocations, DirectoryLocation, DirectoryMerchantDetailsTableHead
 import {useMidManagementLocations} from 'hooks/useMidManagementLocations'
 import {requestModal} from 'features/modalSlice'
 import {CommentsSubjectTypes, ModalType} from 'utils/enums'
-import {setCommentsSubjectType, setModalHeader} from 'features/directoryCommentsSlice'
+import {setCommentsRef, setCommentsSubjectType, setModalHeader} from 'features/directoryCommentsSlice'
 
 const locationsTableHeaders: DirectoryMerchantDetailsTableHeader[] = [
   {
@@ -127,6 +127,7 @@ const DirectoryMerchantLocations = () => {
   const requestBulkCommentModal = () => {
     setSelectedLocations()
     dispatch(setModalHeader('Location Comment'))
+    dispatch(setCommentsRef(merchantId as string))
     dispatch(setCommentsSubjectType(CommentsSubjectTypes.LOCATION))
     dispatch(requestModal(ModalType.MID_MANAGEMENT_BULK_COMMENT))
   }

--- a/src/components/DirectoryMerchantMids/DirectoryMerchantMids.tsx
+++ b/src/components/DirectoryMerchantMids/DirectoryMerchantMids.tsx
@@ -5,7 +5,7 @@ import {CommentsSubjectTypes, ModalType, PaymentSchemeName} from 'utils/enums'
 import {useAppDispatch, useAppSelector} from 'app/hooks'
 import {requestModal} from 'features/modalSlice'
 import {getSelectedDirectoryTableCheckedRefs, setSelectedDirectoryEntityCheckedSelection, setSelectedDirectoryMerchantEntity, setSelectedDirectoryMerchantPaymentScheme} from 'features/directoryMerchantSlice'
-import {setModalHeader, setCommentsSubjectType} from 'features/directoryCommentsSlice'
+import {setModalHeader, setCommentsSubjectType, setCommentsRef} from 'features/directoryCommentsSlice'
 import AddVisaSvg from 'icons/svgs/add-visa.svg'
 import AddMastercardSvg from 'icons/svgs/add-mastercard.svg'
 import AddAmexSvg from 'icons/svgs/add-amex.svg'
@@ -106,6 +106,7 @@ const DirectoryMerchantMids = () => {
   const requestBulkCommentModal = () => {
     setSelectedMids()
     dispatch(setModalHeader('MID Comment'))
+    dispatch(setCommentsRef(merchantId as string))
     dispatch(setCommentsSubjectType(CommentsSubjectTypes.MERCHANT))
     dispatch(requestModal(ModalType.MID_MANAGEMENT_BULK_COMMENT))
   }

--- a/src/components/DirectoryMerchantSecondaryMids/DirectoryMerchantSecondaryMids.tsx
+++ b/src/components/DirectoryMerchantSecondaryMids/DirectoryMerchantSecondaryMids.tsx
@@ -10,7 +10,7 @@ import AddVisaSvg from 'icons/svgs/add-visa.svg'
 import AddMastercardSvg from 'icons/svgs/add-mastercard.svg'
 import {DirectoryMerchantDetailsTableHeader, DirectoryMerchantDetailsTableCell} from 'types'
 import {CommentsSubjectTypes, ModalType} from 'utils/enums'
-import {setCommentsSubjectType, setModalHeader} from 'features/directoryCommentsSlice'
+import {setCommentsRef, setCommentsSubjectType, setModalHeader} from 'features/directoryCommentsSlice'
 
 const secondaryMidsTableHeaders: DirectoryMerchantDetailsTableHeader[] = [
   {
@@ -99,6 +99,7 @@ const DirectoryMerchantSecondaryMids = () => {
   const requestBulkCommentModal = () => {
     setSelectedSecondaryMids()
     dispatch(setModalHeader('Secondary MID Comment'))
+    dispatch(setCommentsRef(merchantId as string))
     dispatch(setCommentsSubjectType(CommentsSubjectTypes.SECONDARY_MID))
     dispatch(requestModal(ModalType.MID_MANAGEMENT_BULK_COMMENT))
   }

--- a/src/components/Modals/components/BulkCommentModal/BulkCommentModal.tsx
+++ b/src/components/Modals/components/BulkCommentModal/BulkCommentModal.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useState} from 'react'
 import {useAppSelector} from 'app/hooks'
 import {useMidManagementComments} from 'hooks/useMidManagementComments'
 import {Modal, AutosizeTextArea, PaymentCardIcon} from 'components'
-import {getCommentsModalHeader, getCommentsSubjectType} from 'features/directoryCommentsSlice'
+import {getCommentsRef, getCommentsModalHeader, getCommentsSubjectType} from 'features/directoryCommentsSlice'
 import {getSelectedDirectoryEntityCheckedSelection} from 'features/directoryMerchantSlice'
 import {ModalStyle} from 'utils/enums'
 import {determineCommentOwnerType} from 'utils/comments'
@@ -10,6 +10,7 @@ import {DirectoryMerchantEntitySelectedItem} from 'types'
 import CheckSvg from 'icons/svgs/check.svg'
 
 const BulkCommentModal = () => {
+  const commentsRef = useAppSelector(getCommentsRef)
   const commentsModalHeader = useAppSelector(getCommentsModalHeader)
   const commentsSubjectType = useAppSelector(getCommentsSubjectType)
   const checkedSubjects = useAppSelector(getSelectedDirectoryEntityCheckedSelection)
@@ -31,8 +32,7 @@ const BulkCommentModal = () => {
     if (checkedRefs.length !== 0) {
       postComment({
         metadata: {
-          // TODO: Use actual user ID
-          comment_owner: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+          comment_owner: commentsRef as string,
           owner_type: determineCommentOwnerType(commentsSubjectType),
           text: comment,
         },
@@ -42,7 +42,7 @@ const BulkCommentModal = () => {
     } else {
       setNoSubjectsValidationIsError(true)
     }
-  }, [postComment, commentsSubjectType, checkedRefs])
+  }, [postComment, commentsSubjectType, checkedRefs, commentsRef])
 
   const handleCheckboxChange = (ref: string) => {
     setNoSubjectsValidationIsError(false)

--- a/src/components/Modals/components/DirectoryCommentsModal/DirectoryCommentsModal.tsx
+++ b/src/components/Modals/components/DirectoryCommentsModal/DirectoryCommentsModal.tsx
@@ -36,8 +36,7 @@ const DirectoryCommentsModal = () => {
     postComment({
       commentsRef,
       metadata: {
-        // TODO: Use actual user ID
-        comment_owner: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        comment_owner: commentsRef,
         owner_type: determineCommentOwnerType(commentsSubjectType),
         text: comment,
       },

--- a/src/components/Modals/components/DirectorySingleViewModal/components/SingleViewComments/SingleViewComments.tsx
+++ b/src/components/Modals/components/DirectorySingleViewModal/components/SingleViewComments/SingleViewComments.tsx
@@ -30,8 +30,7 @@ const SingleViewComments = ({subjectType}: Props) => {
     postComment({
       commentsRef: commentsRef as string,
       metadata: {
-        // TODO: Use actual user ID
-        comment_owner: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        comment_owner: commentsRef as string,
         owner_type: determineCommentOwnerType(subjectType),
         text: comment,
       },


### PR DESCRIPTION
Update the POST comment functionality to se the owner type as the entity ref rather than the user ID