### PR TITLE
Hotfix: PTL-493 New Psimi

### DIFF
--- a/src/components/Modals/components/DirectoryMidModal/DirectoryMidModal.tsx
+++ b/src/components/Modals/components/DirectoryMidModal/DirectoryMidModal.tsx
@@ -69,7 +69,7 @@ const DirectoryMidModal = () => {
       if (midValue === '') {
         setMidValidationError('Enter MID')
       } else {
-        const paymentSchemeSlug: PaymentSchemeSlug = PaymentSchemeSlug[paymentScheme]
+        const paymentSchemeSlug: PaymentSchemeSlug = PaymentSchemeSlug[paymentScheme.toUpperCase()]
         const metadata = {
           payment_scheme_slug: paymentSchemeSlug,
           mid: midValue,

--- a/src/components/Modals/components/DirectoryPsimiModal/DirectoryPsimiModal.tsx
+++ b/src/components/Modals/components/DirectoryPsimiModal/DirectoryPsimiModal.tsx
@@ -63,7 +63,7 @@ const DirectoryPsimiModal = () => {
       if (psimiValue === '') {
         setPsimiValidationError('Enter PSIMI')
       } else {
-        const paymentSchemeSlug = PaymentSchemeSlug[paymentScheme]
+        const paymentSchemeSlug = PaymentSchemeSlug[paymentScheme.toUpperCase()]
         const metadata = {
           value: psimiValue,
           payment_scheme_merchant_name: null, // Never populated for a new PSIMI


### PR DESCRIPTION
Mastercard not being a valid payment scheme name

Fix for Mid and Psimi modals.

