### PR TITLE
PTL-607 Get rid of parent location dropdown in Edit Sublocation modal

### DIFF
--- a/src/__tests__/DirectoryMerchantLocationForm.test.tsx
+++ b/src/__tests__/DirectoryMerchantLocationForm.test.tsx
@@ -64,8 +64,8 @@ const mockCancelHandler = jest.fn()
 
 const mockProps = {
   location: mockLocation,
-  isSubLocation: false,
-  isLocationSubLocation: false,
+  isExistingSubLocation: false,
+  isNewLocationSubLocation: false,
   setIsInEditState: jest.fn(),
   parentLocationStrings: [],
   parentLocation: 'None',
@@ -363,25 +363,38 @@ describe('DirectoryMerchantLocationForm', () => {
 
   describe('Test sub-location appearance', () => {
     it('should not render the location id field', () => {
-      render(getDirectoryMerchantModalComponent({isSubLocation: true}))
+      render(getDirectoryMerchantModalComponent({isExistingSubLocation: true}))
       expect(screen.queryByLabelText('Location ID')).not.toBeInTheDocument()
     })
 
     it('should not render the merchant internal id field', () => {
-      render(getDirectoryMerchantModalComponent({isSubLocation: true}))
+      render(getDirectoryMerchantModalComponent({isExistingSubLocation: true}))
       expect(screen.queryByLabelText('Merchant Internal ID')).not.toBeInTheDocument()
     })
-  })
 
-  describe('Test location sub-location appearance', () => {
     it('should render the parent location as text', () => {
-      render(getDirectoryMerchantModalComponent({isLocationSubLocation: true}))
+      render(getDirectoryMerchantModalComponent({isExistingSubLocation: true}))
       expect(screen.getByTestId('parent-location')).toHaveTextContent(mockProps.parentLocation)
       expect(screen.queryByTestId('parent-location-dropdown')).not.toBeInTheDocument()
     })
 
     it('should not render the Parent Location info message', () => {
-      render(getDirectoryMerchantModalComponent({parentLocation: 'selected_location', isLocationSubLocation: true}))
+      render(getDirectoryMerchantModalComponent({parentLocation: 'selected_location', isNewLocationSubLocation: true}))
+      expect(screen.queryByText(
+        'This location will be created as a sub-location and will inherit the MID & Secondary MID information of its parent location. You will not be able to add MIDs to this sub-location'
+      )).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Test location sub-location appearance', () => {
+    it('should render the parent location as text', () => {
+      render(getDirectoryMerchantModalComponent({isNewLocationSubLocation: true}))
+      expect(screen.getByTestId('parent-location')).toHaveTextContent(mockProps.parentLocation)
+      expect(screen.queryByTestId('parent-location-dropdown')).not.toBeInTheDocument()
+    })
+
+    it('should not render the Parent Location info message', () => {
+      render(getDirectoryMerchantModalComponent({parentLocation: 'selected_location', isNewLocationSubLocation: true}))
       expect(screen.queryByText(
         'This location will be created as a sub-location and will inherit the MID & Secondary MID information of its parent location. You will not be able to add MIDs to this sub-location'
       )).not.toBeInTheDocument()

--- a/src/components/DirectoryMerchantLocationForm/DirectoryMerchantLocationForm.tsx
+++ b/src/components/DirectoryMerchantLocationForm/DirectoryMerchantLocationForm.tsx
@@ -12,8 +12,8 @@ import {SerializedError} from '@reduxjs/toolkit'
 
 type Props = {
   location?: DirectoryLocation
-  isLocationSubLocation?: boolean
-  isSubLocation?: boolean
+  isNewLocationSubLocation?: boolean
+  isExistingSubLocation?: boolean
   setIsInEditState?: (isInEditState: boolean) => void
   parentLocationStrings: string[]
   parentLocation: string
@@ -28,8 +28,8 @@ type Props = {
 
 const DirectoryMerchantLocationForm = ({
   location,
-  isLocationSubLocation,
-  isSubLocation,
+  isNewLocationSubLocation,
+  isExistingSubLocation,
   setIsInEditState,
   parentLocationStrings,
   parentLocation,
@@ -59,7 +59,7 @@ const DirectoryMerchantLocationForm = ({
   } = location?.location_metadata || {}
 
   const [nameValue, setNameValue] = useState(() => {
-    if (name && !isLocationSubLocation) {
+    if (name && !isNewLocationSubLocation) {
       return name
     }
     return ''
@@ -117,7 +117,7 @@ const DirectoryMerchantLocationForm = ({
         setIsInEditState(false)
       }
     }
-  }, [isSuccess, handleErrorResponse, dispatch, router, planId, merchantId, tab, error, resetResponse, isSubLocation, setIsInEditState])
+  }, [isSuccess, handleErrorResponse, dispatch, router, planId, merchantId, tab, error, resetResponse, isExistingSubLocation, setIsInEditState])
 
   const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setNameValue(event.target.value)
@@ -232,14 +232,14 @@ const DirectoryMerchantLocationForm = ({
         <h2 className='font-modal-heading'>PARENT LOCATION</h2>
 
         <div className='h-[28px] w-[277px]'>
-          {isLocationSubLocation ? <p className='font-body-2' data-testid='parent-location'>{parentLocation}</p> : <Dropdown
+          {isExistingSubLocation || isNewLocationSubLocation ? <p className='font-body-2' data-testid='parent-location'>{parentLocation}</p> : <Dropdown
             displayValue={parentLocation}
             displayValues={parentLocationStrings}
             onChangeDisplayValue={handleParentLocationChange}
           />}
         </div>
 
-        {parentLocation !== 'None' && !isLocationSubLocation && (
+        {parentLocation !== 'None' && !isExistingSubLocation && !isNewLocationSubLocation && (
           <p className='font-subheading-4 mt-[10px] w-[489px]'>
             This location will be created as a sub-location and will inherit the MID & Secondary MID information of its parent location. You will not be able to add MIDs to this sub-location
           </p>
@@ -266,7 +266,7 @@ const DirectoryMerchantLocationForm = ({
           inputColour={nameValidationError ? InputColour.RED : InputColour.GREY}
         />
 
-        {parentLocation === 'None' && !isSubLocation && (
+        {parentLocation === 'None' && !isExistingSubLocation && (
           <div className='flex gap-[40px] pt-[28px]'>
             <TextInputGroup
               name='location-id'

--- a/src/components/Modals/components/DirectorySingleViewModal/components/SingleViewLocation/components/SingleViewLocationSubLocations/SingleViewLocationSubLocations.tsx
+++ b/src/components/Modals/components/DirectorySingleViewModal/components/SingleViewLocation/components/SingleViewLocationSubLocations/SingleViewLocationSubLocations.tsx
@@ -40,8 +40,7 @@ const SingleViewLocationSubLocations = ({location, isInEditState, setIsInEditSta
   const renderNewSubLocationForm = () => (
     <DirectoryMerchantLocationForm
       location={location}
-      isLocationSubLocation={true}
-      isSubLocation={true}
+      isNewLocationSubLocation={true}
       parentLocationStrings={null}
       parentLocation={location.location_metadata.name}
       parentLocationChangeHandler={null}

--- a/src/components/Modals/components/DirectorySingleViewModal/components/SingleViewSubLocation/components/SingleViewSubLocationDetails/SingleViewSubLocationDetails.tsx
+++ b/src/components/Modals/components/DirectorySingleViewModal/components/SingleViewSubLocation/components/SingleViewSubLocationDetails/SingleViewSubLocationDetails.tsx
@@ -125,7 +125,7 @@ const SingleViewSubLocationDetails = ({isInEditState, location, setIsInEditState
       {isInEditState ? (
         <DirectoryMerchantLocationForm
           location={subLocation}
-          isSubLocation={true}
+          isExistingSubLocation={true}
           setIsInEditState={setIsInEditState}
           parentLocationStrings={['None']}
           parentLocation={'None'}


### PR DESCRIPTION
removed the ability to render the dropdown for an existing sublocation