### PR TITLE
MER-2186-delete-psimis-bug

### DIFF
--- a/src/components/DirectoryMerchantPsimis/DirectoryMerchantPsimis.tsx
+++ b/src/components/DirectoryMerchantPsimis/DirectoryMerchantPsimis.tsx
@@ -101,7 +101,7 @@ const DirectoryMerchantPsimis = () => {
 
   const requestPsimisDeleteModal = ():void => {
     setSelectedPsimis()
-    dispatch(requestModal(ModalType.MID_MANAGEMENT_DIRECTORY_SECONDARY_MIDS_DELETE))
+    dispatch(requestModal(ModalType.MID_MANAGEMENT_DIRECTORY_PSIMIS_DELETE))
   }
 
   const requestBulkCommentModal = () => {


### PR DESCRIPTION
fix: psimis delete modal using Secondary Mids instead