### PR TITLE
hotfix-6-mer-2208-sharing-link-metadata

### DIFF
--- a/src/components/HeadMetadata/HeadMetadata.tsx
+++ b/src/components/HeadMetadata/HeadMetadata.tsx
@@ -5,17 +5,13 @@ type Props = {
     pageDescription: string;
 }
 
-const HeadMetadata = ({pageTitle, pageDescription = 'test to see if this overrides'}: Props) => (
-  <Head>
-    <title>Aperture {pageTitle}</title>
-    <meta name='description' content={pageDescription} />
-    <meta property='og:title' content={pageTitle} />
-    <meta property='og:description' content={pageDescription} />
-    <meta property='og:image' content='/icons/pngs/aperture-transparent.png' />
-    <meta property='og:image:width' content='505' />
-    <meta property='og:image:height' content='494' />
-    <meta property='og:site_name' content='Aperture' />
-  </Head>
-)
+const HeadMetadata = ({pageTitle, pageDescription = 'test to see if this overrides'}: Props) => {
+  console.log('HeadMetadata', pageTitle, pageDescription)
+  return (
+    <Head>
+      <title>Aperture {pageTitle}</title>
+      <meta name='description' content={pageDescription} />
+    </Head>
+  ) }
 
 export default HeadMetadata

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -7,6 +7,10 @@ const Document = () => <Html>
     <link href='https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&family=Roboto:wght@400;500;700&display=swap' rel='stylesheet'/>
     <meta property='og:title' content='Aperture - Bink Internal Portal' />
     <meta property='og:description' content='This is coming from document' />
+    <meta property='og:image' content='/icons/pngs/aperture-transparent.png' />
+    <meta property='og:image:width' content='400' />
+    <meta property='og:image:height' content='400' />
+    <meta property='og:site_name' content='Aperture' />
   </Head>
   <body>
     <Main />


### PR DESCRIPTION
change: fully transfer to _document